### PR TITLE
Fix repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pip install syntract
 ### Development Installation
 
 ```bash
-git clone https://github.com/your-repo/syntract.git
+git clone https://github.com/Sparsh57/Syntract.git
 cd syntract
 pip install -e .
 ```
@@ -396,8 +396,8 @@ python -m synthesis.compare_interpolation
 - [CuPy](https://cupy.dev/) - GPU-accelerated computing
 
 ## Support
-- **Issues**: [GitHub Issues](https://github.com/your-repo/syntract/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/your-repo/syntract/discussions)
+- **Issues**: [GitHub Issues](https://github.com/Sparsh57/Syntract/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/Sparsh57/Syntract/discussions)
 
 ---
 


### PR DESCRIPTION
## Summary
- update repo reference links in README so they point to Sparsh57/Syntract

## Testing
- `pytest -q` *(fails: process_and_save() got an unexpected keyword argument)*

------
https://chatgpt.com/codex/tasks/task_e_684c48ea635883279c5efd102999b8b8